### PR TITLE
Add active thread percentage configuration for MPS daemon

### DIFF
--- a/cmd/mps-control-daemon/mps/daemon.go
+++ b/cmd/mps-control-daemon/mps/daemon.go
@@ -83,8 +83,9 @@ func (e envvars) toSlice() []string {
 // TODO: Set CUDA_VISIBLE_DEVICES to include only the devices for this resource type.
 func (d *Daemon) EnvVars() envvars {
 	return map[string]string{
-		"CUDA_MPS_PIPE_DIRECTORY": d.PipeDir(),
-		"CUDA_MPS_LOG_DIRECTORY":  d.LogDir(),
+		"CUDA_MPS_PIPE_DIRECTORY":           d.PipeDir(),
+		"CUDA_MPS_LOG_DIRECTORY":            d.LogDir(),
+		"CUDA_MPS_ACTIVE_THREAD_PERCENTAGE": d.activeThreadPercentage(),
 	}
 }
 
@@ -274,6 +275,11 @@ func (m *Daemon) activeThreadPercentage() string {
 	if len(m.Devices()) == 0 {
 		return ""
 	}
+
+	if pct := os.Getenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE"); pct != "" {
+		return pct
+	}
+
 	replicasPerDevice := len(m.Devices()) / len(m.Devices().GetUUIDs())
 
 	return fmt.Sprintf("%d", 100/replicasPerDevice)

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -171,6 +171,10 @@ spec:
             value: all
           - name: NVIDIA_DRIVER_CAPABILITIES
             value: compute,utility
+        {{- if ne .Values.mps.daemon.activeThreadPercentage "0" }}
+          - name: CUDA_MPS_ACTIVE_THREAD_PERCENTAGE
+            value: {{ .Values.mps.daemon.activeThreadPercentage }}
+        {{- end }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -145,6 +145,11 @@ nfd:
           - vendor
 
 mps:
+  daemon:
+    # activeThreadPercentage is the percentage of active threads to use for MPS.
+    # This is set to 0 by default (which means 100/replicas), but can be overridden by setting the
+    # CUDA_MPS_ACTIVE_THREAD_PERCENTAGE environment variable in the pod spec.
+    activeThreadPercentage: "0"
   # root specifies the location where files and folders for managing MPS will
   # be created. This includes a daemon-specific /dev/shm and pipe and log
   # directories.


### PR DESCRIPTION
- Introduced CUDA_MPS_ACTIVE_THREAD_PERCENTAGE environment variable in the daemon.
- Updated values.yaml to allow customization of active thread percentage.